### PR TITLE
Check if all in one controller is actually enabled in the configuration

### DIFF
--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -53,7 +53,7 @@ jobs:
       build-target: windows
       unityversion: ${{ needs.Setup-Unity.outputs.unityeditorversion }}
       # Check inside yml file for instructions on dependencies
-      dependencies: '[{"rcdevelopment": "github.com/realitycollective/com.realitytoolkit.core.git"},{"pico_dependencies": "github.com/realitycollective/com.realitytoolkit.pico.git"}]'
+      dependencies: '[{"development": "github.com/realitycollective/com.realitytoolkit.core.git"},{"pico_dependencies": "github.com/realitycollective/com.realitytoolkit.pico.git"}]'
     secrets:
       GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}    
       GIT_PAT: ${{ secrets.GIT_PAT }} 

--- a/Runtime/InputSystem/Providers/PicoControllerDataProvider.cs
+++ b/Runtime/InputSystem/Providers/PicoControllerDataProvider.cs
@@ -27,16 +27,31 @@ namespace RealityToolkit.Pico.InputSystem.Providers
             : base(name, priority, profile, parentService) { }
 
         private readonly Dictionary<Handedness, PicoController> activeControllers = new Dictionary<Handedness, PicoController>();
+        private bool allInOneHeadsetButtonsControllerEnabled;
+
+        /// <inheritdoc />
+        public override void Initialize()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            allInOneHeadsetButtonsControllerEnabled = TryGetControllerMappingProfile(typeof(PicoAllInOneHeadsetButtonsController), Handedness.None, out _);
+        }
 
         /// <inheritdoc />
         public override void Update()
         {
-            // The all-in-one controller is located on the Pico headset itself and always available.
-            // It also doesn't have a handedness associated.
-            var headsetController = GetOrAddController(Handedness.None, typeof(PicoAllInOneHeadsetButtonsController));
-            if (headsetController != null)
+            if (allInOneHeadsetButtonsControllerEnabled)
             {
-                headsetController.UpdateController();
+                // The all-in-one controller is located on the Pico headset itself and always available.
+                // It also doesn't have a handedness associated.
+                var headsetController = GetOrAddController(Handedness.None, typeof(PicoAllInOneHeadsetButtonsController));
+                if (headsetController != null)
+                {
+                    headsetController.UpdateController();
+                }
             }
 
             // We allow one type of controller per hand, check if there is a controller connected
@@ -146,7 +161,7 @@ namespace RealityToolkit.Pico.InputSystem.Providers
             }
             catch (Exception ex)
             {
-                UnityEngine.Debug.LogError($"Failed to create {type.Name}!\n{ex}");
+                Debug.LogError($"Failed to create {type.Name}!\n{ex}");
                 return null;
             }
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/realitycollective"
   },
   "dependencies": {
-    "com.realitytoolkit.core": "1.0.0-preview.1"
+    "com.realitytoolkit.core": "1.0.0-preview.2"
   },
   "assets": [
     {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Some users may decide to not support the Pico headset controller at all and remove it's configuration profile from the data provider's configuration. This would cause issues with the data provider because it would always try to create the headset controller and run into exceptions.

## Changes

See above.

## Related Submodule Changes

- https://github.com/realitycollective/com.realitytoolkit.core/pull/14/files

## Testing status

* No tests have been added.

### Manual testing status

Manually tested by removing the controller mapping profile.