### PR TITLE
Fix root namespace to RealityToolkit

### DIFF
--- a/Editor/PicoCameraDataProviderProfileInspector.cs
+++ b/Editor/PicoCameraDataProviderProfileInspector.cs
@@ -4,8 +4,8 @@
 using RealityToolkit.Pico.CameraSystem.Profiles;
 using UnityEditor;
 using UnityEngine;
-using XRTK.Editor.Extensions;
-using XRTK.Editor.Profiles.CameraSystem;
+using RealityToolkit.Editor.Extensions;
+using RealityToolkit.Editor.Profiles.CameraSystem;
 
 namespace RealityToolkit.Pico.Editor
 {

--- a/Editor/PicoControllerDataProviderProfileInspector.cs
+++ b/Editor/PicoControllerDataProviderProfileInspector.cs
@@ -3,7 +3,7 @@
 
 using RealityToolkit.Pico.InputSystem.Profiles;
 using UnityEditor;
-using XRTK.Editor.Profiles.InputSystem.Controllers;
+using RealityToolkit.Editor.Profiles.InputSystem.Controllers;
 
 namespace RealityToolkit.Pico.Editor
 {

--- a/Editor/PicoPackageInstaller.cs
+++ b/Editor/PicoPackageInstaller.cs
@@ -3,9 +3,9 @@
 
 using System.IO;
 using UnityEditor;
-using XRTK.Editor;
-using XRTK.Editor.Utilities;
-using XRTK.Extensions;
+using RealityToolkit.Editor;
+using RealityToolkit.Editor.Utilities;
+using RealityToolkit.Extensions;
 
 namespace RealityToolkit.Pico.Editor
 {

--- a/Editor/PicoPathFinder.cs
+++ b/Editor/PicoPathFinder.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
-using XRTK.Editor.Utilities;
+using RealityToolkit.Editor.Utilities;
 
 namespace RealityToolkit.Pico.Editor
 {

--- a/Runtime/CameraSystem/Profiles/PicoCameraDataProviderProfile.cs
+++ b/Runtime/CameraSystem/Profiles/PicoCameraDataProviderProfile.cs
@@ -3,7 +3,7 @@
 
 using Unity.XR.PXR;
 using UnityEngine;
-using XRTK.Definitions.CameraSystem;
+using RealityToolkit.Definitions.CameraSystem;
 
 namespace RealityToolkit.Pico.CameraSystem.Profiles
 {

--- a/Runtime/CameraSystem/Providers/PicoCameraDataProvider.cs
+++ b/Runtime/CameraSystem/Providers/PicoCameraDataProvider.cs
@@ -4,9 +4,9 @@
 using RealityToolkit.Pico.CameraSystem.Profiles;
 using Unity.XR.PXR;
 using UnityEngine;
-using XRTK.Attributes;
-using XRTK.Interfaces.CameraSystem;
-using XRTK.Services.CameraSystem.Providers;
+using RealityToolkit.Attributes;
+using RealityToolkit.Interfaces.CameraSystem;
+using RealityToolkit.Services.CameraSystem.Providers;
 
 namespace RealityToolkit.Pico.CameraSystem.Providers
 {

--- a/Runtime/Extensions/HandednessExtensions.cs
+++ b/Runtime/Extensions/HandednessExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Unity.XR.PXR;
-using XRTK.Definitions.Utilities;
+using RealityToolkit.Definitions.Utilities;
 
 namespace RealityToolkit.Pico.Extensions
 {

--- a/Runtime/InputSystem/Controllers/PicoAllInOneHeadsetButtonsController.cs
+++ b/Runtime/InputSystem/Controllers/PicoAllInOneHeadsetButtonsController.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
-using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.Utilities;
-using XRTK.Extensions;
-using XRTK.Interfaces.InputSystem.Providers.Controllers;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Extensions;
+using RealityToolkit.Interfaces.InputSystem.Providers.Controllers;
 
 namespace RealityToolkit.Pico.InputSystem.Controllers
 {

--- a/Runtime/InputSystem/Controllers/PicoController.cs
+++ b/Runtime/InputSystem/Controllers/PicoController.cs
@@ -4,12 +4,12 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
-using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.Utilities;
-using XRTK.Extensions;
-using XRTK.Interfaces.InputSystem.Providers.Controllers;
-using XRTK.Services.InputSystem.Controllers;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Extensions;
+using RealityToolkit.Interfaces.InputSystem.Providers.Controllers;
+using RealityToolkit.Services.InputSystem.Controllers;
 
 namespace RealityToolkit.Pico.InputSystem.Controllers
 {

--- a/Runtime/InputSystem/Controllers/PicoG24KController.cs
+++ b/Runtime/InputSystem/Controllers/PicoG24KController.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
-using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.Utilities;
-using XRTK.Interfaces.InputSystem.Providers.Controllers;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Interfaces.InputSystem.Providers.Controllers;
 
 namespace RealityToolkit.Pico.InputSystem.Controllers
 {

--- a/Runtime/InputSystem/Controllers/PicoNeo2Controller.cs
+++ b/Runtime/InputSystem/Controllers/PicoNeo2Controller.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
-using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.Utilities;
-using XRTK.Interfaces.InputSystem.Providers.Controllers;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Interfaces.InputSystem.Providers.Controllers;
 
 namespace RealityToolkit.Pico.InputSystem.Controllers
 {

--- a/Runtime/InputSystem/Controllers/PicoNeo3Controller.cs
+++ b/Runtime/InputSystem/Controllers/PicoNeo3Controller.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
-using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.Utilities;
-using XRTK.Interfaces.InputSystem.Providers.Controllers;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Interfaces.InputSystem.Providers.Controllers;
 
 namespace RealityToolkit.Pico.InputSystem.Controllers
 {

--- a/Runtime/InputSystem/Profiles/PicoControllerDataProviderProfile.cs
+++ b/Runtime/InputSystem/Profiles/PicoControllerDataProviderProfile.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityToolkit.Pico.InputSystem.Controllers;
-using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Utilities;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Utilities;
 
 namespace RealityToolkit.Pico.InputSystem.Profiles
 {

--- a/Runtime/InputSystem/Providers/PicoControllerDataProvider.cs
+++ b/Runtime/InputSystem/Providers/PicoControllerDataProvider.cs
@@ -7,11 +7,11 @@ using System;
 using System.Collections.Generic;
 using Unity.XR.PXR;
 using UnityEngine;
-using XRTK.Attributes;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.Utilities;
-using XRTK.Interfaces.InputSystem;
-using XRTK.Services.InputSystem.Controllers;
+using RealityToolkit.Attributes;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Interfaces.InputSystem;
+using RealityToolkit.Services.InputSystem.Controllers;
 
 namespace RealityToolkit.Pico.InputSystem.Providers
 {

--- a/Runtime/PicoPlatform.cs
+++ b/Runtime/PicoPlatform.cs
@@ -4,8 +4,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
-using XRTK.Definitions.Platforms;
-using XRTK.Interfaces;
+using RealityToolkit.Definitions.Platforms;
+using RealityToolkit.Interfaces;
 
 namespace RealityToolkit.Pico
 {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Replaces the old `XRTK` root namespace with `RealityToolkit`.