### PR TITLE
Ensure platform loader is active when checking platform availability

### DIFF
--- a/Runtime/PicoPlatform.cs
+++ b/Runtime/PicoPlatform.cs
@@ -22,6 +22,10 @@ namespace RealityToolkit.Pico
         private const string xrDisplaySubsystemDescriptorId = "PicoXR Display";
         private const string xrInputSubsystemDescriptorId = "PicoXR Input";
 
+        private bool IsXRLoaderActive => XRGeneralSettings.Instance.IsNotNull() &&
+                    ((XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.GetType() == typeof(PXR_Loader)) ||
+                    (XRGeneralSettings.Instance.Manager.activeLoaders != null && XRGeneralSettings.Instance.Manager.activeLoaders.Any(l => l.GetType() == typeof(PXR_Loader))));
+
         /// <inheritdoc />
         public override IPlatform[] PlatformOverrides { get; } =
         {
@@ -33,12 +37,7 @@ namespace RealityToolkit.Pico
         {
             get
             {
-                var xrLoaderIsActive =
-                    XRGeneralSettings.Instance.IsNotNull() &&
-                    ((XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.GetType() == typeof(PXR_Loader)) ||
-                    (XRGeneralSettings.Instance.Manager.activeLoaders != null && XRGeneralSettings.Instance.Manager.activeLoaders.Any(l => l.GetType() == typeof(PXR_Loader))));
-
-                if (!xrLoaderIsActive)
+                if (!IsXRLoaderActive)
                 {
                     // The platform XR loader is not active.
                     return false;
@@ -93,6 +92,9 @@ namespace RealityToolkit.Pico
         }
 
 #if UNITY_EDITOR
+        /// <inheritdoc />
+        public override bool IsBuildTargetAvailable => IsXRLoaderActive && base.IsBuildTargetAvailable;
+
         /// <inheritdoc />
         public override UnityEditor.BuildTarget[] ValidBuildTargets { get; } =
         {

--- a/Runtime/PicoPlatform.cs
+++ b/Runtime/PicoPlatform.cs
@@ -1,11 +1,15 @@
 // Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityCollective.Extensions;
 using RealityCollective.ServiceFramework.Definitions.Platforms;
 using RealityCollective.ServiceFramework.Interfaces;
 using System.Collections.Generic;
+using System.Linq;
+using Unity.XR.PXR;
 using UnityEngine;
 using UnityEngine.XR;
+using UnityEngine.XR.Management;
 
 namespace RealityToolkit.Pico
 {
@@ -29,6 +33,17 @@ namespace RealityToolkit.Pico
         {
             get
             {
+                var xrLoaderIsActive =
+                    XRGeneralSettings.Instance.IsNotNull() &&
+                    ((XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.GetType() == typeof(PXR_Loader)) ||
+                    (XRGeneralSettings.Instance.Manager.activeLoaders != null && XRGeneralSettings.Instance.Manager.activeLoaders.Any(l => l.GetType() == typeof(PXR_Loader))));
+
+                if (!xrLoaderIsActive)
+                {
+                    // The platform XR loader is not active.
+                    return false;
+                }
+
                 var displaySubsystems = new List<XRDisplaySubsystem>();
                 SubsystemManager.GetSubsystems(displaySubsystems);
                 var xrDisplaySubsystemDescriptorFound = false;

--- a/Runtime/RealityToolkit.Pico.asmdef
+++ b/Runtime/RealityToolkit.Pico.asmdef
@@ -5,7 +5,8 @@
         "GUID:f3241d040533491e8a1e2714b27c3111",
         "GUID:781d3f72e45b2ed46b35a96cb2736482",
         "GUID:b2d046948d6452a4b8485efc9ce0f88c",
-        "GUID:13703f41b24bb904cb2305abe6317e3d"
+        "GUID:13703f41b24bb904cb2305abe6317e3d",
+        "GUID:e40ba710768534012815d3193fa296cb"
     ],
     "includePlatforms": [
         "Android",


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Fixes the issue that the Pico platform is considered enabled / available even when e.g. targeting Oculus in the editor. This was causing issues with service registration since Pico data providers would register even when we are actually wanting Oculus providers to available only.

The new check ensures that the Pico platform loader is actually active in the XR Plugin Management and only then, the platform is considered available.

## Changes

See code.