### PR TITLE
Feature/restore legacy support

### DIFF
--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController.meta
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13ac1bcb6a538884fb2602923aa4faf3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController.asset
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d420c170b42dfe0438e2aa2a829775ed, type: 3}
+  m_Name: PicoAllInOneHeadsetButtonsController
+  m_EditorClassIdentifier: 
+  controllerType:
+    reference: f661ead7-06fc-422b-918c-84c711bf9b6b
+  handedness: 0
+  visualizationProfile: {fileID: 0}
+  useCustomInteractions: 0
+  interactionMappingProfiles:
+  - {fileID: 11400000, guid: 286e7a6f30821fa4e969b2d222e83e22, type: 2}
+  - {fileID: 11400000, guid: a572dfd3a3b00b245807bddd9e643850, type: 2}

--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController.asset.meta
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4043ca69eeaaf8b42b6a5cadd62b9b7f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Menu.asset
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Menu.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: PicoAllInOneHeadsetButtonsController_Menu
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Menu
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 2
+      description: Menu
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Menu
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Menu.asset.meta
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Menu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a572dfd3a3b00b245807bddd9e643850
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Trigger.asset
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Trigger.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: PicoAllInOneHeadsetButtonsController_Trigger
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 1
+      description: Select
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Trigger
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Trigger.asset.meta
+++ b/Assets~/Profiles/InputService/PicoAllInOneHeadsetButtonsController/PicoAllInOneHeadsetButtonsController_Trigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 286e7a6f30821fa4e969b2d222e83e22
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoControllerServiceModuleProfile.asset
+++ b/Assets~/Profiles/InputService/PicoControllerServiceModuleProfile.asset
@@ -14,6 +14,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hasSetupDefaults: 1
   controllerMappingProfiles:
+  - {fileID: 11400000, guid: 4043ca69eeaaf8b42b6a5cadd62b9b7f, type: 2}
+  - {fileID: 11400000, guid: b3de4000c219ae4419453fd99cad5c74, type: 2}
+  - {fileID: 11400000, guid: e020b02af905e3e4d9a9fda1dc24863d, type: 2}
+  - {fileID: 11400000, guid: e80f840176f296a49af66d1740fee240, type: 2}
+  - {fileID: 11400000, guid: 1204423f058281348be1c320ab00af96, type: 2}
   - {fileID: 11400000, guid: 43abbd94bd95dcc41b3f61cae733fc55, type: 2}
   - {fileID: 11400000, guid: 3535d92a7a302e240bed29df161173f7, type: 2}
   - {fileID: 11400000, guid: 51c4549d11ed180439c1776922dbe9cb, type: 2}

--- a/Assets~/Profiles/InputService/PicoG24KController.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9166bdff29e637446a2c53d61ba4fd3b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d420c170b42dfe0438e2aa2a829775ed, type: 3}
+  m_Name: LeftPicoG24KController
+  m_EditorClassIdentifier: 
+  controllerType:
+    reference: 07b23b0b-1be1-4ac5-942e-0fe3bc65a260
+  handedness: 1
+  visualizationProfile: {fileID: 11400000, guid: fe125eaaf5547684d8506b794c5a6016,
+    type: 2}
+  useCustomInteractions: 0
+  interactionMappingProfiles:
+  - {fileID: 11400000, guid: 6b245c09c96a948499c6e03a12213ec1, type: 2}
+  - {fileID: 11400000, guid: cef45cf68144cb94d99652a76c9fcfcb, type: 2}
+  - {fileID: 11400000, guid: 1fdc26adcd9687e4a982dcb765ba7b04, type: 2}
+  - {fileID: 11400000, guid: 7cbd0c8f71621c540b6e2131129e96da, type: 2}
+  - {fileID: 11400000, guid: 5dd5894f4d84e5f4c92191213aa848db, type: 2}
+  - {fileID: 11400000, guid: 384ddbd5f740873489df5e2291e4c091, type: 2}

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3de4000c219ae4419453fd99cad5c74
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Menu.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Menu.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoG24KController_Menu
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Menu
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 2
+      description: Menu
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Menu
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Menu.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Menu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cef45cf68144cb94d99652a76c9fcfcb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_SpatialPointerPose.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_SpatialPointerPose.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoG24KController_SpatialPointerPose
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Spatial Pointer Pose
+    stateChangeType: 0
+    axisType: 7
+    inputType: 3
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 4
+      description: Pointer Pose
+      axisConstraint: 7
+    keyCode: 0
+    inputName: Spatial Pointer Pose
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles:
+  - {fileID: 11400000, guid: 9e0e4acc675a18b4b9c65e9ff85cfe58, type: 2}
+  - {fileID: 11400000, guid: d3736f91cbeeb284fb90b9d389b7fe33, type: 2}

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_SpatialPointerPose.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_SpatialPointerPose.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b245c09c96a948499c6e03a12213ec1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Touchpad.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Touchpad.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoG24KController_Touchpad
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Touchpad
+    stateChangeType: 0
+    axisType: 4
+    inputType: 17
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 5
+      description: Teleport Direction
+      axisConstraint: 4
+    keyCode: 0
+    inputName: Touchpad
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Touchpad.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Touchpad.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dd5894f4d84e5f4c92191213aa848db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TouchpadPress.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TouchpadPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoG24KController_TouchpadPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Touchpad Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: Touchpad Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TouchpadPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TouchpadPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 384ddbd5f740873489df5e2291e4c091
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Trigger.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Trigger.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoG24KController_Trigger
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger
+    stateChangeType: 0
+    axisType: 3
+    inputType: 10
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 6
+      description: Trigger
+      axisConstraint: 3
+    keyCode: 0
+    inputName: Trigger
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Trigger.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_Trigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fdc26adcd9687e4a982dcb765ba7b04
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TriggerPress.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TriggerPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoG24KController_TriggerPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 1
+      description: Select
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Trigger Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TriggerPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/LeftPicoG24KController_TriggerPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cbd0c8f71621c540b6e2131129e96da
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d420c170b42dfe0438e2aa2a829775ed, type: 3}
+  m_Name: RightPicoG24KController
+  m_EditorClassIdentifier: 
+  controllerType:
+    reference: 07b23b0b-1be1-4ac5-942e-0fe3bc65a260
+  handedness: 2
+  visualizationProfile: {fileID: 11400000, guid: 5ee67c77447ce88409a3e04e57806963,
+    type: 2}
+  useCustomInteractions: 0
+  interactionMappingProfiles:
+  - {fileID: 11400000, guid: 501e2e67b3ed96c4fb1bea991a104875, type: 2}
+  - {fileID: 11400000, guid: ec012d348b9e7c147bd766cb67cbaf7b, type: 2}
+  - {fileID: 11400000, guid: e8f621edf55951249a15d381c3e30573, type: 2}
+  - {fileID: 11400000, guid: 386ab3e8fbd566d4b8303648a4fe5692, type: 2}
+  - {fileID: 11400000, guid: b44df9c60a47eea45aaa1e806a80b9f2, type: 2}
+  - {fileID: 11400000, guid: 603653c4368665e4c9d23ba8a36bfb11, type: 2}

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e020b02af905e3e4d9a9fda1dc24863d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Menu.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Menu.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoG24KController_Menu
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Menu
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 2
+      description: Menu
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Menu
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Menu.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Menu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec012d348b9e7c147bd766cb67cbaf7b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_SpatialPointerPose.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_SpatialPointerPose.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoG24KController_SpatialPointerPose
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Spatial Pointer Pose
+    stateChangeType: 0
+    axisType: 7
+    inputType: 3
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 4
+      description: Pointer Pose
+      axisConstraint: 7
+    keyCode: 0
+    inputName: Spatial Pointer Pose
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles:
+  - {fileID: 11400000, guid: 9e0e4acc675a18b4b9c65e9ff85cfe58, type: 2}
+  - {fileID: 11400000, guid: d3736f91cbeeb284fb90b9d389b7fe33, type: 2}

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_SpatialPointerPose.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_SpatialPointerPose.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 501e2e67b3ed96c4fb1bea991a104875
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Touchpad.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Touchpad.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoG24KController_Touchpad
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Touchpad
+    stateChangeType: 0
+    axisType: 4
+    inputType: 17
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 5
+      description: Teleport Direction
+      axisConstraint: 4
+    keyCode: 0
+    inputName: Touchpad
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Touchpad.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Touchpad.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b44df9c60a47eea45aaa1e806a80b9f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TouchpadPress.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TouchpadPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoG24KController_TouchpadPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Touchpad Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: Touchpad Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TouchpadPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TouchpadPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 603653c4368665e4c9d23ba8a36bfb11
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Trigger.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Trigger.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoG24KController_Trigger
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger
+    stateChangeType: 0
+    axisType: 3
+    inputType: 10
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 6
+      description: Trigger
+      axisConstraint: 3
+    keyCode: 0
+    inputName: Trigger
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Trigger.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_Trigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8f621edf55951249a15d381c3e30573
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TriggerPress.asset
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TriggerPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoG24KController_TriggerPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 1
+      description: Select
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Trigger Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TriggerPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoG24KController/RightPicoG24KController_TriggerPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 386ab3e8fbd566d4b8303648a4fe5692
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b588c14ad5c883044a6368496e3c3bad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d420c170b42dfe0438e2aa2a829775ed, type: 3}
+  m_Name: LeftPicoNeo2Controller
+  m_EditorClassIdentifier: 
+  controllerType:
+    reference: 5402e1d6-466e-438e-8667-0ab654eb8780
+  handedness: 1
+  visualizationProfile: {fileID: 11400000, guid: fe125eaaf5547684d8506b794c5a6016,
+    type: 2}
+  useCustomInteractions: 0
+  interactionMappingProfiles:
+  - {fileID: 11400000, guid: cd4a36ddd192f544d83a75a9cacd254e, type: 2}
+  - {fileID: 11400000, guid: 8d829d41ef56d284c8fea26d450eb0e4, type: 2}
+  - {fileID: 11400000, guid: f69b0a69c406601449b9b58a3582988f, type: 2}
+  - {fileID: 11400000, guid: 55f0598b19837c748b2aacb85f66dcac, type: 2}
+  - {fileID: 11400000, guid: 60e6b89c0a3afb9408bf0901ce67c9a4, type: 2}
+  - {fileID: 11400000, guid: e5ed509547b99264c8149918274d8ad9, type: 2}
+  - {fileID: 11400000, guid: bafffdec7d909b046a54f58fc1cb9664, type: 2}
+  - {fileID: 11400000, guid: efbcb464a6249e94f8d579041cf8b669, type: 2}
+  - {fileID: 11400000, guid: ca2f9f1342581b74c8d7fb82c64128f9, type: 2}
+  - {fileID: 11400000, guid: f72b795de0cf0a942935bf509e2b2023, type: 2}

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e80f840176f296a49af66d1740fee240
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Grip.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Grip.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_Grip
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Grip
+    stateChangeType: 0
+    axisType: 3
+    inputType: 10
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 7
+      description: Grip Strength
+      axisConstraint: 3
+    keyCode: 0
+    inputName: Grip
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Grip.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Grip.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60e6b89c0a3afb9408bf0901ce67c9a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_GripPress.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_GripPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_GripPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Grip Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 16
+      description: Grip Press
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Grip Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_GripPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_GripPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5ed509547b99264c8149918274d8ad9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Menu.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Menu.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_Menu
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Menu
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 2
+      description: Menu
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Menu
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Menu.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Menu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d829d41ef56d284c8fea26d450eb0e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_SpatialPointerPose.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_SpatialPointerPose.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_SpatialPointerPose
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Spatial Pointer Pose
+    stateChangeType: 0
+    axisType: 7
+    inputType: 3
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 4
+      description: Pointer Pose
+      axisConstraint: 7
+    keyCode: 0
+    inputName: Spatial Pointer Pose
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles:
+  - {fileID: 11400000, guid: 9e0e4acc675a18b4b9c65e9ff85cfe58, type: 2}
+  - {fileID: 11400000, guid: d3736f91cbeeb284fb90b9d389b7fe33, type: 2}

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_SpatialPointerPose.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_SpatialPointerPose.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd4a36ddd192f544d83a75a9cacd254e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Thumbstick.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Thumbstick.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_Thumbstick
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Thumbstick
+    stateChangeType: 0
+    axisType: 4
+    inputType: 17
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 5
+      description: Teleport Direction
+      axisConstraint: 4
+    keyCode: 0
+    inputName: Thumbstick
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Thumbstick.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Thumbstick.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca2f9f1342581b74c8d7fb82c64128f9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_ThumbstickPress.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_ThumbstickPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_ThumbstickPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Thumbstick Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: Thumbstick Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_ThumbstickPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_ThumbstickPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f72b795de0cf0a942935bf509e2b2023
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Trigger.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Trigger.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_Trigger
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger
+    stateChangeType: 0
+    axisType: 3
+    inputType: 10
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 6
+      description: Trigger
+      axisConstraint: 3
+    keyCode: 0
+    inputName: Trigger
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Trigger.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Trigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f69b0a69c406601449b9b58a3582988f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_TriggerPress.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_TriggerPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_TriggerPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 1
+      description: Select
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Trigger Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_TriggerPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_TriggerPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55f0598b19837c748b2aacb85f66dcac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_X.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_X.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_X
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: X
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: X
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_X.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_X.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bafffdec7d909b046a54f58fc1cb9664
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Y.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Y.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: LeftPicoNeo2Controller_Y
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Y
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: Y
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Y.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/LeftPicoNeo2Controller_Y.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: efbcb464a6249e94f8d579041cf8b669
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d420c170b42dfe0438e2aa2a829775ed, type: 3}
+  m_Name: RightPicoNeo2Controller
+  m_EditorClassIdentifier: 
+  controllerType:
+    reference: 5402e1d6-466e-438e-8667-0ab654eb8780
+  handedness: 2
+  visualizationProfile: {fileID: 11400000, guid: 5ee67c77447ce88409a3e04e57806963,
+    type: 2}
+  useCustomInteractions: 0
+  interactionMappingProfiles:
+  - {fileID: 11400000, guid: a100700f9775a1742ae120e7b9c79c42, type: 2}
+  - {fileID: 11400000, guid: 7986e4b79b22fa04caa975610d192d55, type: 2}
+  - {fileID: 11400000, guid: 02e7c925e18bc7241847645919babb79, type: 2}
+  - {fileID: 11400000, guid: 7b671c372c062304582b70c89ad9aff4, type: 2}
+  - {fileID: 11400000, guid: 6c22da7990d07914bad3403c3bce77fe, type: 2}
+  - {fileID: 11400000, guid: cf378592126f8f14db141386991867e6, type: 2}
+  - {fileID: 11400000, guid: 7cd6a80bd579fc644b1511d0468b1e50, type: 2}
+  - {fileID: 11400000, guid: f8466eb5284d0cb48a6d85d58b52eb42, type: 2}
+  - {fileID: 11400000, guid: 3b0510687b529c740980310aa7708965, type: 2}
+  - {fileID: 11400000, guid: e76a2fe0e4fd5c14fba18d79638b87c5, type: 2}

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1204423f058281348be1c320ab00af96
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Grip.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Grip.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_Grip
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Grip
+    stateChangeType: 0
+    axisType: 3
+    inputType: 10
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 7
+      description: Grip Strength
+      axisConstraint: 3
+    keyCode: 0
+    inputName: Grip
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Grip.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Grip.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c22da7990d07914bad3403c3bce77fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_GripPress.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_GripPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_GripPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Grip Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 16
+      description: Grip Press
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Grip Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_GripPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_GripPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf378592126f8f14db141386991867e6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Menu.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Menu.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_Menu
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Menu
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 2
+      description: Menu
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Menu
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Menu.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Menu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7986e4b79b22fa04caa975610d192d55
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_SpatialPointerPose.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_SpatialPointerPose.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_SpatialPointerPose
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Spatial Pointer Pose
+    stateChangeType: 0
+    axisType: 7
+    inputType: 3
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 4
+      description: Pointer Pose
+      axisConstraint: 7
+    keyCode: 0
+    inputName: Spatial Pointer Pose
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles:
+  - {fileID: 11400000, guid: 9e0e4acc675a18b4b9c65e9ff85cfe58, type: 2}
+  - {fileID: 11400000, guid: d3736f91cbeeb284fb90b9d389b7fe33, type: 2}

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_SpatialPointerPose.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_SpatialPointerPose.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a100700f9775a1742ae120e7b9c79c42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Thumbstick.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Thumbstick.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_Thumbstick
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Thumbstick
+    stateChangeType: 0
+    axisType: 4
+    inputType: 17
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 5
+      description: Teleport Direction
+      axisConstraint: 4
+    keyCode: 0
+    inputName: Thumbstick
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Thumbstick.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Thumbstick.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b0510687b529c740980310aa7708965
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_ThumbstickPress.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_ThumbstickPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_ThumbstickPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Thumbstick Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: Thumbstick Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_ThumbstickPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_ThumbstickPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e76a2fe0e4fd5c14fba18d79638b87c5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Trigger.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Trigger.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_Trigger
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger
+    stateChangeType: 0
+    axisType: 3
+    inputType: 10
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 6
+      description: Trigger
+      axisConstraint: 3
+    keyCode: 0
+    inputName: Trigger
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Trigger.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Trigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02e7c925e18bc7241847645919babb79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_TriggerPress.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_TriggerPress.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_TriggerPress
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Trigger Press
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 1
+      description: Select
+      axisConstraint: 2
+    keyCode: 0
+    inputName: Trigger Press
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_TriggerPress.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_TriggerPress.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b671c372c062304582b70c89ad9aff4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_X.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_X.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_X
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: X
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: X
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_X.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_X.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cd6a80bd579fc644b1511d0468b1e50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Y.asset
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Y.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3fb79524faca40478c0844c24e542f7, type: 3}
+  m_Name: RightPicoNeo2Controller_Y
+  m_EditorClassIdentifier: 
+  interactionMapping:
+    description: Y
+    stateChangeType: 0
+    axisType: 2
+    inputType: 7
+    inputAction:
+      profileGuid: 00000000000000000000000000000000
+      id: 0
+      description: None
+      axisConstraint: 0
+    keyCode: 0
+    inputName: Y
+    axisCodeX: 
+    axisCodeY: 
+    inputProcessors: []
+  pointerProfiles: []

--- a/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Y.asset.meta
+++ b/Assets~/Profiles/InputService/PicoNeo2Controller/RightPicoNeo2Controller_Y.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8466eb5284d0cb48a6d85d58b52eb42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/StandardAssets/RESERVED_FOR_FUTURE_USE.txt.meta
+++ b/Assets~/StandardAssets/RESERVED_FOR_FUTURE_USE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3176a27d95068464e88015ae75896cfa
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ This package enables your Reality Toolkit based project to run on PICO devices.
 
 ## Supported Devices
 
-- PICO Neo3 Pro
-- PICO Neo3 Link
-- PICO Neo3 Pro Eye
+- PICO G24K*
+- PICO Neo 2*
+- PICO Neo 3 Pro
+- PICO Neo 3 Link
+- PICO Neo 3 Pro Eye
 - PICO 4
 - PICO 4 Pro
 - PICO 4 Enterprise
+
+*Requires the legacy v1 Pico integration SDK package as a dependency
 
 ## Requirements
 

--- a/Runtime/InputService/PicoAllInOneHeadsetButtonsController.cs
+++ b/Runtime/InputService/PicoAllInOneHeadsetButtonsController.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.Definitions.Utilities;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.InputSystem.Extensions;
+using RealityToolkit.InputSystem.Interfaces.Modules;
+using UnityEngine;
+
+namespace RealityToolkit.Pico.InputService
+{
+    /// <summary>
+    /// The <see cref="PicoAllInOneHeadsetButtonsController"/> is located on the Pico headset itself
+    /// and has only two buttons. One for selecting and one for going back. It's a common feature of all
+    /// Pico devices and operates using the user's gaze.
+    /// </summary>
+    [System.Runtime.InteropServices.Guid("f661ead7-06fc-422b-918c-84c711bf9b6b")]
+    public class PicoAllInOneHeadsetButtonsController : PicoController
+    {
+        /// <inheritdoc />
+        public PicoAllInOneHeadsetButtonsController() { }
+
+        /// <inheritdoc />
+        public PicoAllInOneHeadsetButtonsController(IMixedRealityControllerServiceModule controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)
+            : base(controllerDataProvider, trackingState, controllerHandedness, controllerMappingProfile) { }
+
+        private const string triggerButtonInputName = "Trigger";
+        private const string menuButtonInputName = "Menu";
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultInteractions => new[]
+        {
+            new MixedRealityInteractionMapping(triggerButtonInputName, AxisType.Digital, triggerButtonInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(menuButtonInputName, AxisType.Digital, menuButtonInputName, DeviceInputType.ButtonPress)
+        };
+
+        /// <inheritdoc />
+        protected override void UpdateTrackingState()
+        {
+            if (TrackingState != TrackingState.NotApplicable)
+            {
+                TrackingState = TrackingState.NotApplicable;
+                InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void UpdateInteractionMappings()
+        {
+            Debug.Assert(Interactions != null && Interactions.Length > 0, $"Interaction mappings must be defined for {GetType().Name} - {ControllerHandedness}.");
+
+            for (var i = 0; i < Interactions.Length; i++)
+            {
+                var interactionMapping = Interactions[i];
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.ButtonPress:
+                        UpdateButtonPress(interactionMapping);
+                        break;
+                    default:
+                        Debug.LogError($"Input {interactionMapping.InputType} is not handled for controller {GetType().Name} - {ControllerHandedness}.");
+                        break;
+                }
+
+                interactionMapping.RaiseInputAction(InputSource, ControllerHandedness);
+            }
+        }
+
+        private void UpdateButtonPress(MixedRealityInteractionMapping interactionMapping)
+        {
+            Debug.Assert(interactionMapping.AxisType == AxisType.Digital);
+
+            if (interactionMapping.InputName.Equals(triggerButtonInputName))
+            {
+                interactionMapping.BoolData = Input.GetKey(KeyCode.JoystickButton0);
+            }
+            else if (interactionMapping.InputName.Equals(menuButtonInputName))
+            {
+                interactionMapping.BoolData = Input.GetKey(KeyCode.Escape);
+            }
+        }
+    }
+}

--- a/Runtime/InputService/PicoAllInOneHeadsetButtonsController.cs.meta
+++ b/Runtime/InputService/PicoAllInOneHeadsetButtonsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff1dd1985a0083d42b37b8ee48f27aba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/InputService/PicoControllerServiceModule.cs
+++ b/Runtime/InputService/PicoControllerServiceModule.cs
@@ -27,9 +27,39 @@ namespace RealityToolkit.Pico.InputService
 
         private readonly Dictionary<Handedness, PicoController> activeControllers = new Dictionary<Handedness, PicoController>();
 
+#if PICO_XR_LEGACY
+        private bool allInOneHeadsetButtonsControllerEnabled;
+#endif
+
+#if PICO_XR_LEGACY
+        /// <inheritdoc />
+        public override void Initialize()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            allInOneHeadsetButtonsControllerEnabled = TryGetControllerMappingProfile(typeof(PicoAllInOneHeadsetButtonsController), Handedness.None, out _);
+        }
+#endif
+
         /// <inheritdoc />
         public override void Update()
         {
+#if PICO_XR_LEGACY
+            if (allInOneHeadsetButtonsControllerEnabled)
+            {
+                // The all-in-one controller is located on the Pico headset itself and always available.
+                // It also doesn't have a handedness associated.
+                var headsetController = GetOrAddController(Handedness.None, typeof(PicoAllInOneHeadsetButtonsController));
+                if (headsetController != null)
+                {
+                    headsetController.UpdateController();
+                }
+            }
+#endif
+
             // We allow one type of controller per hand, check if there is a controller connected
             // for the left hand and update accordingly.
             if (PXR_Input.IsControllerConnected(PXR_Input.Controller.LeftController))
@@ -62,6 +92,14 @@ namespace RealityToolkit.Pico.InputService
             PicoController controller;
             switch (activeControllerDeviceType)
             {
+#if PICO_XR_LEGACY
+                case PXR_Input.ControllerDevice.G2:
+                    controller = GetOrAddController(handedness, typeof(PicoG24KController));
+                    break;
+                case PXR_Input.ControllerDevice.Neo2:
+                    controller = GetOrAddController(handedness, typeof(PicoNeo2Controller));
+                    break;
+#endif
                 case PXR_Input.ControllerDevice.Neo3:
                     controller = GetOrAddController(handedness, typeof(PicoNeo3Controller));
                     break;

--- a/Runtime/InputService/PicoG24KController.cs
+++ b/Runtime/InputService/PicoG24KController.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.Definitions.Utilities;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.InputSystem.Interfaces.Modules;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace RealityToolkit.Pico.InputService
+{
+    [System.Runtime.InteropServices.Guid("07b23b0b-1be1-4ac5-942e-0fe3bc65a260")]
+    public class PicoG24KController : PicoController
+    {
+        /// <inheritdoc />
+        public PicoG24KController() { }
+
+        /// <inheritdoc />
+        public PicoG24KController(IMixedRealityControllerServiceModule controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)
+            : base(controllerDataProvider, trackingState, controllerHandedness, controllerMappingProfile) { }
+
+        private const string menuButtonInputName = "Menu";
+        private const string triggerInputName = "Trigger";
+        private const string triggerPressInputName = "Trigger Press";
+        private const string touchpadInputName = "Touchpad";
+        private const string touchpadPressInputName = "Touchpad Press";
+        private const string spatialPointerPoseInputName = "Spatial Pointer Pose";
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultInteractions => new[]
+        {
+            new MixedRealityInteractionMapping(spatialPointerPoseInputName, AxisType.SixDof, spatialPointerPoseInputName, DeviceInputType.SpatialPointer),
+            new MixedRealityInteractionMapping(menuButtonInputName, AxisType.Digital, menuButtonInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(triggerInputName, AxisType.SingleAxis, triggerInputName, DeviceInputType.Trigger),
+            new MixedRealityInteractionMapping(triggerPressInputName, AxisType.Digital, triggerPressInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(touchpadInputName, AxisType.DualAxis, touchpadInputName, DeviceInputType.ThumbStick),
+            new MixedRealityInteractionMapping(touchpadPressInputName, AxisType.Digital, touchpadPressInputName, DeviceInputType.ButtonPress)
+        };
+
+        /// <inheritdoc />
+        protected override IReadOnlyDictionary<string, InputFeatureUsage<bool>> DigitalInputFeatureUsageMap { get; set; } = new Dictionary<string, InputFeatureUsage<bool>>
+        {
+            { menuButtonInputName, CommonUsages.menuButton },
+            { triggerPressInputName, CommonUsages.triggerButton },
+            { touchpadPressInputName, CommonUsages.primary2DAxisClick }
+        };
+
+        /// <inheritdoc />
+        protected override IReadOnlyDictionary<string, InputFeatureUsage<float>> SingleAxisInputFeatureUsageMap { get; set; } = new Dictionary<string, InputFeatureUsage<float>>
+        {
+            { triggerInputName, CommonUsages.trigger }
+        };
+
+        /// <inheritdoc />
+        protected override IReadOnlyDictionary<string, InputFeatureUsage<Vector2>> DualAxisInputFeatureUsageMap { get; set; } = new Dictionary<string, InputFeatureUsage<Vector2>>
+        {
+            { touchpadInputName, CommonUsages.primary2DAxis }
+        };
+    }
+}

--- a/Runtime/InputService/PicoG24KController.cs.meta
+++ b/Runtime/InputService/PicoG24KController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdca989eb12104645bef2f1e5dafbf42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/InputService/PicoNeo2Controller.cs
+++ b/Runtime/InputService/PicoNeo2Controller.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.Definitions.Utilities;
+using RealityToolkit.Definitions.Controllers;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.InputSystem.Interfaces.Modules;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace RealityToolkit.Pico.InputService
+{
+    [System.Runtime.InteropServices.Guid("5402e1d6-466e-438e-8667-0ab654eb8780")]
+    public class PicoNeo2Controller : PicoController
+    {
+        /// <inheritdoc />
+        public PicoNeo2Controller() { }
+
+        /// <inheritdoc />
+        public PicoNeo2Controller(IMixedRealityControllerServiceModule controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)
+            : base(controllerDataProvider, trackingState, controllerHandedness, controllerMappingProfile) { }
+
+        private const string menuButtonInputName = "Menu";
+        private const string triggerInputName = "Trigger";
+        private const string triggerPressInputName = "Trigger Press";
+        private const string gripInputName = "Grip";
+        private const string gripPressInputName = "Grip Press";
+        private const string thumbstickInputName = "Thumbstick";
+        private const string thumbstickPressInputName = "Thumbstick Press";
+        private const string spatialPointerPoseInputName = "Spatial Pointer Pose";
+        private const string xButtonInputName = "X";
+        private const string yButtonInputName = "Y";
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultInteractions => new[]
+        {
+            new MixedRealityInteractionMapping(spatialPointerPoseInputName, AxisType.SixDof, spatialPointerPoseInputName, DeviceInputType.SpatialPointer),
+            new MixedRealityInteractionMapping(menuButtonInputName, AxisType.Digital, menuButtonInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(triggerInputName, AxisType.SingleAxis, triggerInputName, DeviceInputType.Trigger),
+            new MixedRealityInteractionMapping(triggerPressInputName, AxisType.Digital, triggerPressInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(gripInputName, AxisType.SingleAxis, gripInputName, DeviceInputType.Trigger),
+            new MixedRealityInteractionMapping(gripPressInputName, AxisType.Digital, gripPressInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(xButtonInputName, AxisType.Digital, xButtonInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(yButtonInputName, AxisType.Digital, yButtonInputName, DeviceInputType.ButtonPress),
+            new MixedRealityInteractionMapping(thumbstickInputName, AxisType.DualAxis, thumbstickInputName, DeviceInputType.ThumbStick),
+            new MixedRealityInteractionMapping(thumbstickPressInputName, AxisType.Digital, thumbstickPressInputName, DeviceInputType.ButtonPress)
+        };
+
+        /// <inheritdoc />
+        protected override IReadOnlyDictionary<string, InputFeatureUsage<bool>> DigitalInputFeatureUsageMap { get; set; } = new Dictionary<string, InputFeatureUsage<bool>>
+        {
+            { menuButtonInputName, CommonUsages.menuButton },
+            { triggerPressInputName, CommonUsages.triggerButton },
+            { gripPressInputName, CommonUsages.gripButton },
+            { thumbstickPressInputName, CommonUsages.primary2DAxisClick },
+            { xButtonInputName, CommonUsages.primaryButton },
+            { yButtonInputName, CommonUsages.secondaryButton }
+        };
+
+        /// <inheritdoc />
+        protected override IReadOnlyDictionary<string, InputFeatureUsage<float>> SingleAxisInputFeatureUsageMap { get; set; } = new Dictionary<string, InputFeatureUsage<float>>
+        {
+            { triggerInputName, CommonUsages.trigger },
+            { gripInputName, CommonUsages.grip }
+        };
+
+        /// <inheritdoc />
+        protected override IReadOnlyDictionary<string, InputFeatureUsage<Vector2>> DualAxisInputFeatureUsageMap { get; set; } = new Dictionary<string, InputFeatureUsage<Vector2>>
+        {
+            { thumbstickInputName, CommonUsages.primary2DAxis }
+        };
+    }
+}

--- a/Runtime/InputService/PicoNeo2Controller.cs.meta
+++ b/Runtime/InputService/PicoNeo2Controller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad4c4b82b76a6034b96f33c55b1733b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/InputService/Profiles/PicoControllerServiceModuleProfile.cs
+++ b/Runtime/InputService/Profiles/PicoControllerServiceModuleProfile.cs
@@ -7,7 +7,7 @@ using RealityToolkit.Definitions.Controllers;
 namespace RealityToolkit.Pico.InputService.Profiles
 {
     /// <summary>
-    /// Configuration profile for <see cref="Providers.PicoControllerDataProvider"/>.
+    /// Configuration profile for <see cref="InputService.PicoControllerServiceModule"/>.
     /// </summary>
     public class PicoControllerServiceModuleProfile : BaseMixedRealityControllerServiceModuleProfile
     {
@@ -16,6 +16,11 @@ namespace RealityToolkit.Pico.InputService.Profiles
         {
             return new[]
             {
+                new ControllerDefinition(typeof(PicoAllInOneHeadsetButtonsController), Handedness.None),
+                new ControllerDefinition(typeof(PicoG24KController), Handedness.Left),
+                new ControllerDefinition(typeof(PicoG24KController), Handedness.Right),
+                new ControllerDefinition(typeof(PicoNeo2Controller), Handedness.Left),
+                new ControllerDefinition(typeof(PicoNeo2Controller), Handedness.Right),
                 new ControllerDefinition(typeof(PicoNeo3Controller), Handedness.Left),
                 new ControllerDefinition(typeof(PicoNeo3Controller), Handedness.Right),
                 new ControllerDefinition(typeof(Pico4Controller), Handedness.Left),

--- a/Runtime/RealityToolkit.Pico.asmdef
+++ b/Runtime/RealityToolkit.Pico.asmdef
@@ -22,7 +22,7 @@
     "versionDefines": [
         {
             "name": "com.unity.xr.picoxr",
-            "expression": "[1.0,2.0)",
+            "expression": "[1.0,2.0.7]",
             "define": "PICO_XR_LEGACY"
         }
     ],

--- a/Runtime/RealityToolkit.Pico.asmdef
+++ b/Runtime/RealityToolkit.Pico.asmdef
@@ -19,6 +19,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.xr.picoxr",
+            "expression": "[1.0,2.0)",
+            "define": "PICO_XR_LEGACY"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "url": "https://github.com/realitycollective"
   },
   "dependencies": {
-    "com.realitytoolkit.core": "1.0.0-pre.7",
-    "com.unity.xr.picoxr": "2.1.4"
+    "com.realitytoolkit.core": "1.0.0-pre.7"
   },
   "assets": [
     {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Realized I can easily maintain backwards support for legacy devices, such as G24K and Neo 2, by adding a version define to the runtime assembly.

If the Pico Plugin version is up to v2.0.7 the package defines "PICO_XR_LEGACY" and will query for those input devices. On later versions they are not available since support has been removed from the SDK.