### PR TITLE
Add support for live preview and fix platform descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package enables your Reality Toolkit based project to run on PICO devices.
 [![Publish development branch on Merge](https://github.com/realitycollective/com.realitytoolkit.pico/actions/workflows/development-publish.yml/badge.svg)](https://github.com/realitycollective/com.realitytoolkit.pico/actions/workflows/development-publish.yml)
 [![Build and test UPM packages for platforms, all branches except main](https://github.com/realitycollective/com.realitytoolkit.pico/actions/workflows/development-buildandtestupmrelease.yml/badge.svg)](https://github.com/realitycollective/com.realitytoolkit.pico/actions/workflows/development-buildandtestupmrelease.yml)
 
-## What's included?
+## What is included?
 
 - Service modules for the Reality Toolkit's Camera Service
 - Service modules for the Reality Toolkit's Input Service

--- a/Runtime/PicoPlatform.cs
+++ b/Runtime/PicoPlatform.cs
@@ -12,6 +12,8 @@ using UnityEngine.XR.Management;
 
 #if UNITY_EDITOR && !PICO_XR_LEGACY && PICO_XR_LP
 using Unity.XR.PICO.LivePreview;
+#else
+using Unity.XR.PXR;
 #endif
 
 namespace RealityToolkit.Pico

--- a/Runtime/RealityToolkit.Pico.asmdef
+++ b/Runtime/RealityToolkit.Pico.asmdef
@@ -7,7 +7,8 @@
         "GUID:13703f41b24bb904cb2305abe6317e3d",
         "GUID:e40ba710768534012815d3193fa296cb",
         "GUID:65a004a26c89ac5468e8d4b4b057f1c8",
-        "GUID:de07d9dfb71843b46aa2c474f73ca4cc"
+        "GUID:de07d9dfb71843b46aa2c474f73ca4cc",
+        "GUID:f70b6e413e9cf3744b522089b55c7e84"
     ],
     "includePlatforms": [
         "Android",
@@ -24,6 +25,11 @@
             "name": "com.unity.xr.picoxr",
             "expression": "[1.0,2.0.7]",
             "define": "PICO_XR_LEGACY"
+        },
+        {
+            "name": "com.unity.pico.livepreview",
+            "expression": "1.0.0",
+            "define": "PICO_XR_LP"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

- Adds support for the new Pico Live Preview feature to debug apps in editor in play mode
- Fixes an issue where in newer SDKs (>= v2) the platform avaiability was not detected correctly, because subsystem descriptors have changed